### PR TITLE
Wrong OBO id workaround

### DIFF
--- a/oxo-loader/OlsMappingExtractor.py
+++ b/oxo-loader/OlsMappingExtractor.py
@@ -88,6 +88,7 @@ for data in OXO.getOxODatasets():
     prefixToBaseUri[prefix] = OXO.getBaseUrisByPrefixFromOls(prefix)
     prefixToDatasource[prefix] = data
     prefixToPreferred[prefix] = prefix
+    prefixToPreferred[prefix] = prefix.lower() # Hack to get the 'ontogy id' in here as well.
     for altPrefix in data["alternatePrefix"]:
         prefixToPreferred[altPrefix] = prefix
         if "idorgNamespace" in data and data["idorgNamespace"] != '':
@@ -153,8 +154,8 @@ def processSolrDocs(url):
                 baseUris = prefixToBaseUri[fromPrefix]
                 if isinstance(baseUris, list):
                     for baseUri in baseUris:
-                        if fromIri.startwith(baseUri):
-                            fromId = fromIri.replace(baseUri)
+                        if fromIri.startswith(baseUri):
+                            fromId = fromIri.replace(baseUri,"")
 
             if "obo_id" in docs:
                 fromOboId = docs["obo_id"]
@@ -163,8 +164,10 @@ def processSolrDocs(url):
                 if not fromId:
                     fromId = OXO.getIdFromCui(fromOboId)
 
-            if not fromPrefix and not fromId:
+            if not fromPrefix:
                 fromPrefix = OXO.getPrefixFromCui(fromShortForm)
+
+            if not fromId:
                 fromId = OXO.getIdFromCui(fromShortForm)
 
             if not fromPrefix:
@@ -266,13 +269,14 @@ def processSolrDocs(url):
                                 idorgUri = "http://identifiers.org/" + toCurie
                                 terms[toCurie]["uri"] = idorgUri
 
-        print(str(x))
         initUrl = url + "&start=" + str(x) + "&rows=" + str(rows)
         with urllib.request.urlopen(initUrl) as reply:
             json_terms = json.loads(reply.read().decode())
 
 
 # do the query to get docs from solr and process
+#print(str(prefixToPreferred))
+#print(str(prefixToBaseUri))
 
 if not skipEfo:
     processSolrDocs(efoSolrQueryUrl)

--- a/oxo-loader/OxoClient.py
+++ b/oxo-loader/OxoClient.py
@@ -36,6 +36,7 @@ class OXO:
         self.alreadyScoped = {}
         self.olsLabel = {}
         self.olsIri = {}
+        self.olsBaseUri = {}
 
     def saveDatasource (self, prefix, idorgNamespace, title, description, sourceType, baseUri, alternatePrefixes, licence, versionInfo):
         #print "saving new datasource: {},{},{},{},{},{}".format(prefix, idorgNamespace, title, sourceType, baseUri, alternatePrefixes)
@@ -151,6 +152,22 @@ class OXO:
                     self.olsIri[curie] = uri
                     return {'uri': uri, 'label': label}
         return None
+
+    def getBaseUrisByPrefixFromOls(self, prefix):
+        if not self.olsBaseUri:
+            olsurl = self.olsurl+"/ontologies"
+            reply = urllib.request.urlopen(olsurl)
+            if reply.getcode() == 200:
+                anwser = json.load(reply)
+                if "_embedded" in list(anwser.keys()):
+                    ontologies = anwser["_embedded"]["ontologies"]
+                    for ontology in ontologies:
+                        if 'config' in ontology:
+                            if 'preferredPrefix' in ontology['config']:
+                                if 'baseUris' in ontology:
+                                    self.olsBaseUri[ontology['config']['preferredPrefix']] = ontology['baseUris']
+
+        return self.olsBaseUri.get(prefix)
 
     def getLabelFromOls(self, curie):
 

--- a/oxo-loader/OxoClient.py
+++ b/oxo-loader/OxoClient.py
@@ -164,8 +164,8 @@ class OXO:
                     for ontology in ontologies:
                         if 'config' in ontology:
                             if 'preferredPrefix' in ontology['config']:
-                                if 'baseUris' in ontology:
-                                    self.olsBaseUri[ontology['config']['preferredPrefix']] = ontology['baseUris']
+                                if 'baseUris' in ontology['config']:
+                                    self.olsBaseUri[ontology['config']['preferredPrefix']] = ontology['config']['baseUris']
 
         return self.olsBaseUri.get(prefix)
 


### PR DESCRIPTION
Instead of trying to parse the ontology prefix and term id from the OBO id which is currently broken https://github.com/EBISPOT/OLS/issues/401, we query the OLS API to use the base uris to obtain the id, and try to get the prefix from the set of preferredPrefixes. Its fine now, but in the rewrite we should stablise the code for curie generation more.